### PR TITLE
Allow compiling under MSYS2

### DIFF
--- a/config.sub
+++ b/config.sub
@@ -1350,7 +1350,7 @@ case $os in
 	      | -udi* | -eabi* | -lites* | -ieee* | -go32* | -aux* \
 	      | -chorusos* | -chorusrdb* | -cegcc* \
 	      | -cygwin* | -pe* | -psos* | -moss* | -proelf* | -rtems* \
-	      | -mingw32* | -linux-gnu* | -linux-android* \
+	      | -mingw32* | -msys* | -linux-gnu* | -linux-android* \
 	      | -linux-newlib* | -linux-uclibc* \
 	      | -uxpv* | -beos* | -mpeix* | -udk* \
 	      | -interix* | -uwin* | -mks* | -rhapsody* | -darwin* | -opened* \


### PR DESCRIPTION
Fixes "unrecognized system" error when compiling under MSYS2