### PR TITLE
Add exec and execve support

### DIFF
--- a/newlib/configure.host
+++ b/newlib/configure.host
@@ -534,7 +534,7 @@ case "${host}" in
   mips*-psp-*)
   	sys_dir=psp
   	posix_dir=posix
-  	newlib_cflags="${newlib_cflags} -DHAVE_NANOSLEEP -DHAVE_RENAME -DHAVE_FCNTL -D_NO_POSIX_SPAWN -D_NO_EXECVE -DNO_EXEC"
+  	newlib_cflags="${newlib_cflags} -DHAVE_NANOSLEEP -DHAVE_RENAME -DHAVE_FCNTL -D_NO_POSIX_SPAWN"
 	;;
   mmix-knuth-mmixware)
 	sys_dir=mmixware


### PR DESCRIPTION
This PR solves possible issues with fork, wait, and some others.
Additionally, it includes some other `execv` functions, which require `_execve` to be implemented in `libcglue`.

This PR also requires to be merged: https://github.com/pspdev/pspsdk/compare/master...fjtrujy:posixExec?expand=1