### PR TITLE
Allegrex v4.4.0 lock api & Fix `CLOCKS_PER_SEC`

### DIFF
--- a/newlib/configure.host
+++ b/newlib/configure.host
@@ -534,7 +534,7 @@ case "${host}" in
   mips*-psp-*)
   	sys_dir=psp
   	posix_dir=posix
-  	newlib_cflags="${newlib_cflags} -DHAVE_NANOSLEEP -DHAVE_RENAME -DHAVE_FCNTL -D_NO_POSIX_SPAWN"
+  	newlib_cflags="${newlib_cflags} -DHAVE_NANOSLEEP -DHAVE_RENAME -DHAVE_FCNTL -D_NO_POSIX_SPAWN -DHAVE_DD_LOCK"
 	;;
   mmix-knuth-mmixware)
 	sys_dir=mmixware

--- a/newlib/libc/machine/mips/machine/time.h
+++ b/newlib/libc/machine/mips/machine/time.h
@@ -1,0 +1,6 @@
+#ifndef	_MACHTIME_H_
+#define	_MACHTIME_H_
+
+#define _CLOCKS_PER_SEC_ 1000000
+
+#endif	/* _MACHTIME_H_ */

--- a/newlib/libc/misc/lock.c
+++ b/newlib/libc/misc/lock.c
@@ -81,7 +81,9 @@ subroutines are required for linking multi-threaded applications.
 
 /* dummy lock routines and static locks for single-threaded apps */
 
-#ifndef __SINGLE_THREAD__
+#include <newlib.h>
+
+#if defined(__SINGLE_THREAD__)
 
 #include <sys/lock.h>
 

--- a/newlib/libc/sys/psp/sys/dirent.h
+++ b/newlib/libc/sys/psp/sys/dirent.h
@@ -8,6 +8,7 @@ typedef struct __dirdesc {
     char *dd_buf;	/* buffer */
     int dd_len;		/* buffer length */
     int dd_size;	/* amount of data in buffer */
+    void *dd_lock;	/* lock */
 } DIR;
 
 # define __dirfd(dp)	((dp)->dd_fd)


### PR DESCRIPTION
This PR does 2 things:

Newlib by default defines `CLOCKS_PER_SEC` as `1000` which is wrong,. it should be `1000000`.

Official info:
```
The clock() function conforms to ISO/IEC 9899:1990 (“ISO C90”) and Version 3 of the Single UNIX Specification (“SUSv3”) which requires CLOCKS_PER_SEC to be defined as one million.
```

To have thread-safe operations for all the `newlib` operations we have been required to do several PR:

- [`newlib`](https://github.com/pspdev/newlib/pull/11)
- [`psptoolchain-ee`](https://github.com/pspdev/psptoolchain-allegrex/pull/32)
- [`pspsdk`](https://github.com/pspdev/pspsdk/pull/198)

This PR skips the usage of the dummy lock API, letting us implement the specific one in the `pspsdk/libcglue`

Cheers