### PR TITLE
Fix scandir DD_LOCK

### DIFF
--- a/newlib/libc/posix/scandir.c
+++ b/newlib/libc/posix/scandir.c
@@ -123,23 +123,23 @@ scandir(const char *dirname, struct dirent ***namelist,
 		}
 		names[numitems++] = p;
 	}
+#ifdef HAVE_DD_LOCK
+	__lock_release_recursive(dirp->dd_lock);
+#endif
 	closedir(dirp);
 	if (numitems && dcomp != NULL)
 		qsort(names, numitems, sizeof(struct dirent *), (void *)dcomp);
 	*namelist = names;
-#ifdef HAVE_DD_LOCK
-	__lock_release_recursive(dirp->dd_lock);
-#endif
 	return (numitems);
 
 fail:
 	while (numitems > 0)
 		free(names[--numitems]);
 	free(names);
-	closedir(dirp);
 #ifdef HAVE_DD_LOCK
 	__lock_release_recursive(dirp->dd_lock);
 #endif
+	closedir(dirp);
 	return (-1);
 }
 


### PR DESCRIPTION
## Description
Be sure the `__lock_release_recursive(dirp->dd_lock);` is being called before the `closedir(dirp);` otherwise it will crash as the `dirp->dd_lock` is going to be deleted in `closedir` and on top of that the `dirp` is freed also in `closedir`.

This issue has been there in `newlib` for years, however, it wasn't noticed because first of all LOCK API looks to be barely used, and secondly because it also requires the flag `HAVE_DD_LOCK` to be enabled.

Cheers.